### PR TITLE
Allow loading PSR-X arrays

### DIFF
--- a/src/Loader.php
+++ b/src/Loader.php
@@ -120,15 +120,20 @@ class Loader implements LoaderInterface {
       'psr-4' => 'addPsr4',
     );
     foreach ($psrs as $psr => $loader_method) {
-      foreach (static::$psrClassMap[$psr] as $partial_namespace => $tokenized_path) {
-        try {
-          $resolver = new TokenResolver($tokenized_path);
-          $finder = $resolver->resolve();
-          // Get the real path of the prefix.
-          $real_path = $finder->find(static::$seed);
-          $loader->{$loader_method}($partial_namespace, $real_path);
+      foreach (static::$psrClassMap[$psr] as $partial_namespace => $tokenized_paths) {
+        if (!is_array($tokenized_paths)) {
+          $tokenized_paths = array($tokenized_paths);
         }
-        catch (ClassLoaderException $e) {}
+        foreach ($tokenized_paths as $tokenized_path) {
+          try {
+            $resolver = new TokenResolver($tokenized_path);
+            $finder = $resolver->resolve();
+            // Get the real path of the prefix.
+            $real_path = $finder->find(static::$seed);
+            $loader->{$loader_method}($partial_namespace, $real_path);
+          }
+          catch (ClassLoaderException $e) {}
+        }
       }
     }
   }

--- a/src/TokenResolverInterface.php
+++ b/src/TokenResolverInterface.php
@@ -17,4 +17,5 @@ interface TokenResolverInterface {
    *   The path finder class or NULL.
    */
   public function resolve();
+
 }


### PR DESCRIPTION
This will allow us to have an array of paths to contribute to a PSR-4 and PSR-0 partial namespace discovery.

![drupal-unit-autoload 2015-06-15 07-47-22](https://cloud.githubusercontent.com/assets/1140906/8153776/e37492ac-1332-11e5-8394-91730634606d.png)

![photo on 15-06-15 at 07 48](https://cloud.githubusercontent.com/assets/1140906/8153785/fb570f1c-1332-11e5-9e3c-26e39a7e6856.jpg)
