### PR TITLE
Refactor static

### DIFF
--- a/src/AutoloaderBootstrap.php
+++ b/src/AutoloaderBootstrap.php
@@ -50,10 +50,8 @@ class AutoloaderBootstrap {
    * Register the autoloader if it is not registered.
    */
   public function register() {
-    if ($functions = spl_autoload_functions()) {
-      if (array_search(static::AUTOLOAD_FUNCTION, $functions)) {
-        return;
-      }
+    if ($this::checkLoadedAutoloader()) {
+      return;
     }
     // Parse the composer.json.
     $composer_config = json_decode(file_get_contents(static::COMPOSER_CONFIGURATION_NAME));
@@ -112,6 +110,25 @@ class AutoloaderBootstrap {
       'psr-4' => $psr4,
     ));
     Loader::registerPsr($this->loader);
+  }
+
+  /**
+   * Checks if the autoloader has been added.
+   *
+   * @return bool
+   */
+  public static function checkLoadedAutoloader() {
+    $autoloader_str = ltrim(static::AUTOLOAD_FUNCTION, '\\');
+    $autoloader = explode('::', $autoloader_str);
+    foreach (spl_autoload_functions() as $callable) {
+      if (
+        ($callable[0] == $autoloader[0] || $callable[0] == $autoloader[0]) &&
+        $callable[1] == $autoloader[1]
+      ) {
+        return TRUE;
+      }
+    }
+    return FALSE;
   }
 
 }

--- a/src/AutoloaderBootstrap.php
+++ b/src/AutoloaderBootstrap.php
@@ -20,6 +20,13 @@ class AutoloaderBootstrap {
   const COMPOSER_CONFIGURATION_NAME = 'composer.json';
 
   /**
+   * Holds the composer autoloader.
+   *
+   * @var \Composer\Autoload\ClassLoader
+   */
+  protected $loader;
+
+  /**
    * Constructs a AutoloaderBootstrap object.
    *
    * @param \Composer\Autoload\ClassLoader $loader

--- a/src/AutoloaderBootstrap.php
+++ b/src/AutoloaderBootstrap.php
@@ -27,13 +27,23 @@ class AutoloaderBootstrap {
   protected $loader;
 
   /**
+   * Holds the seed.
+   *
+   * @var string
+   */
+  protected $seed;
+
+  /**
    * Constructs a AutoloaderBootstrap object.
    *
    * @param \Composer\Autoload\ClassLoader $loader
    *   The Composer class loader.
+   * @param string $seed
+   *   The seed to find the drupal projects.
    */
-  public function __construct(\Composer\Autoload\ClassLoader $loader) {
+  public function __construct(\Composer\Autoload\ClassLoader $loader, $seed = 'composer.json') {
     $this->loader = $loader;
+    $this->seed = $seed;
   }
 
   /**
@@ -47,7 +57,7 @@ class AutoloaderBootstrap {
     }
     // Parse the composer.json.
     $composer_config = json_decode(file_get_contents(static::COMPOSER_CONFIGURATION_NAME));
-    Loader::setSeed('composer.json');
+    Loader::setSeed($this->seed);
     $this->registerDrupalPaths($composer_config);
     $this->registerPsr($composer_config);
   }

--- a/src/LoaderInterface.php
+++ b/src/LoaderInterface.php
@@ -19,28 +19,28 @@ interface LoaderInterface {
    * @return bool
    *   TRUE if the class is currently available, FALSE otherwise.
    */
-  public static function autoload($class);
+  public function autoload($class);
 
   /**
    * Sets the class map.
    *
    * @param array $class_map
    */
-  public static function setClassMap(array $class_map);
+  public function setClassMap(array $class_map);
 
   /**
    * Sets the PSR class map.
    *
    * @param array[] $class_map
    */
-  public static function setPsrClassMap(array $class_map);
+  public function setPsrClassMap(array $class_map);
 
   /**
    * Sets the seed path.
    *
    * @param string $seed.
    */
-  public static function setSeed($seed);
+  public function setSeed($seed);
 
   /**
    * Helper function to register PSR-0 and PSR-4 based files.
@@ -51,6 +51,6 @@ interface LoaderInterface {
    * @return bool
    *   TRUE if the class was found. FALSE otherwise.
    */
-  public static function registerPsr(\Composer\Autoload\ClassLoader $loader);
+  public function registerPsr(\Composer\Autoload\ClassLoader $loader);
 
 }

--- a/tests/composer.json
+++ b/tests/composer.json
@@ -9,5 +9,11 @@
       "Drupal\\Composer\\ClassLoader\\": "../src/",
       "Drupal\\Composer\\ClassLoader\\Tests\\": "src/"
     }
+  },
+  "class-loader": {
+    "drupal-path": {
+      "\\Tmp": "DRUPAL_ROOT/file.inc",
+      "\\Tmp2": "data/acme.inc"
+    }
   }
 }

--- a/tests/src/AutoloaderBootstrapTest.php
+++ b/tests/src/AutoloaderBootstrapTest.php
@@ -7,6 +7,8 @@
 
 namespace Drupal\Composer\ClassLoader\Tests;
 
+use Drupal\Composer\ClassLoader\AutoloaderBootstrap;
+use Mockery as m;
 /**
  * Class AutoloaderBootstrapTest
  *
@@ -15,5 +17,17 @@ namespace Drupal\Composer\ClassLoader\Tests;
  * @package Drupal\Composer\ClassLoader\Tests
  */
 class AutoloaderBootstrapTest extends \PHPUnit_Framework_TestCase {
+
+  /**
+   * Tests the ::__construct() method.
+   */
+  public function test___construct() {
+    $loader = m::mock('\Composer\Autoload\ClassLoader');
+    $autoloader = new AutoloaderBootstrap($loader);
+    $reflection_property = new \ReflectionProperty(get_class($autoloader), 'loader');
+    $reflection_property->setAccessible(TRUE);
+    $value = $reflection_property->getValue($autoloader);
+    $this->assertEquals($loader, $value);
+  }
 
 }

--- a/tests/src/AutoloaderBootstrapTest.php
+++ b/tests/src/AutoloaderBootstrapTest.php
@@ -30,4 +30,16 @@ class AutoloaderBootstrapTest extends \PHPUnit_Framework_TestCase {
     $this->assertEquals($loader, $value);
   }
 
+  /**
+   * Tests the ::register() method.
+   */
+  public function test_register() {
+    $loader = m::mock('\Composer\Autoload\ClassLoader');
+    $autoloader = new AutoloaderBootstrap($loader);
+    $reflection_property = new \ReflectionProperty(get_class($autoloader), 'loader');
+    $reflection_property->setAccessible(TRUE);
+    $value = $reflection_property->getValue($autoloader);
+    $this->assertEquals($loader, $value);
+  }
+
 }

--- a/tests/src/AutoloaderBootstrapTest.php
+++ b/tests/src/AutoloaderBootstrapTest.php
@@ -24,7 +24,7 @@ class AutoloaderBootstrapTest extends \PHPUnit_Framework_TestCase {
   public function test___construct() {
     $loader = m::mock('\Composer\Autoload\ClassLoader');
     $autoloader = new AutoloaderBootstrap($loader);
-    $reflection_property = new \ReflectionProperty(get_class($autoloader), 'loader');
+    $reflection_property = new \ReflectionProperty(get_class($autoloader), 'classLoader');
     $reflection_property->setAccessible(TRUE);
     $value = $reflection_property->getValue($autoloader);
     $this->assertEquals($loader, $value);
@@ -47,10 +47,10 @@ class AutoloaderBootstrapTest extends \PHPUnit_Framework_TestCase {
     $autoloader = new AutoloaderBootstrap($loader, 'data/docroot/sites/all/modules/testmodule/composer.json');
     $autoloader->register();
 
-    $this->assertTrue($autoloader::checkLoadedAutoloader());
+    $this->assertTrue($autoloader->checkLoadedAutoloader());
     // Make sure that calling to register a second time does not fail.
     $autoloader->register();
-    $this->assertTrue($autoloader::checkLoadedAutoloader());
+    $this->assertTrue($autoloader->checkLoadedAutoloader());
   }
 
 

--- a/tests/src/AutoloaderBootstrapTest.php
+++ b/tests/src/AutoloaderBootstrapTest.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * @file
+ * Contains Drupal\Composer\ClassLoader\Tests\AutoloaderBootstrapTest.
+ */
+
+namespace Drupal\Composer\ClassLoader\Tests;
+
+/**
+ * Class AutoloaderBootstrapTest
+ *
+ * @coversDefaultClass Drupal\Composer\ClassLoader\AutoloaderBootstrap
+ *
+ * @package Drupal\Composer\ClassLoader\Tests
+ */
+class AutoloaderBootstrapTest extends \PHPUnit_Framework_TestCase {
+
+}

--- a/tests/src/AutoloaderBootstrapTest.php
+++ b/tests/src/AutoloaderBootstrapTest.php
@@ -28,18 +28,25 @@ class AutoloaderBootstrapTest extends \PHPUnit_Framework_TestCase {
     $reflection_property->setAccessible(TRUE);
     $value = $reflection_property->getValue($autoloader);
     $this->assertEquals($loader, $value);
+    $reflection_property = new \ReflectionProperty(get_class($autoloader), 'seed');
+    $reflection_property->setAccessible(TRUE);
+    $value = $reflection_property->getValue($autoloader);
+    $this->assertEquals('composer.json', $value);
   }
 
   /**
    * Tests the ::register() method.
+   *
+   * @covers ::load()
+   * @covers ::registerDrupalPaths()
    */
   public function test_register() {
     $loader = m::mock('\Composer\Autoload\ClassLoader');
-    $autoloader = new AutoloaderBootstrap($loader);
-    $reflection_property = new \ReflectionProperty(get_class($autoloader), 'loader');
-    $reflection_property->setAccessible(TRUE);
-    $value = $reflection_property->getValue($autoloader);
-    $this->assertEquals($loader, $value);
+    $autoloader = new AutoloaderBootstrap($loader, 'data/docroot/sites/all/modules/testmodule/composer.json');
+    $autoloader->register();
+    $functions = spl_autoload_functions();
+    $expected = [['Drupal\Composer\ClassLoader\Loader', 'autoload']];
+    $this->assertTrue(in_array($expected, $functions));
   }
 
 }

--- a/tests/src/AutoloaderBootstrapTest.php
+++ b/tests/src/AutoloaderBootstrapTest.php
@@ -37,16 +37,21 @@ class AutoloaderBootstrapTest extends \PHPUnit_Framework_TestCase {
   /**
    * Tests the ::register() method.
    *
+   * @covers ::register()
    * @covers ::load()
    * @covers ::registerDrupalPaths()
+   * @covers ::checkLoadedAutoloader()
    */
   public function test_register() {
     $loader = m::mock('\Composer\Autoload\ClassLoader');
     $autoloader = new AutoloaderBootstrap($loader, 'data/docroot/sites/all/modules/testmodule/composer.json');
     $autoloader->register();
-    $functions = spl_autoload_functions();
-    $expected = [['Drupal\Composer\ClassLoader\Loader', 'autoload']];
-    $this->assertTrue(in_array($expected, $functions));
+
+    $this->assertTrue($autoloader::checkLoadedAutoloader());
+    // Make sure that calling to register a second time does not fail.
+    $autoloader->register();
+    $this->assertTrue($autoloader::checkLoadedAutoloader());
   }
+
 
 }

--- a/tests/src/LoaderTest.php
+++ b/tests/src/LoaderTest.php
@@ -24,11 +24,11 @@ class LoaderTest extends \PHPUnit_Framework_TestCase {
    * @covers ::unprefixClass()
    */
   public function test_autoload() {
-    Loader::setClassMap([
+    $loader = new Loader(__DIR__);
+    $loader->setClassMap([
       '\\Acme' => './data/acme.inc',
     ]);
-    Loader::setSeed(__DIR__);
-    $this->assertTrue(Loader::autoload('Acme'));
+    $this->assertTrue($loader->autoload('Acme'));
   }
 
   /**
@@ -38,11 +38,11 @@ class LoaderTest extends \PHPUnit_Framework_TestCase {
    * @covers ::autoloadPaths()
    */
   public function test_autoload_unexisting() {
-    Loader::setClassMap([
+    $loader = new Loader(__DIR__);
+    $loader->setClassMap([
       '\\Acme' => './data/acme.inc',
     ]);
-    Loader::setSeed(__DIR__);
-    $this->assertFalse(Loader::autoload('Invalid'));
+    $this->assertFalse($loader->autoload('Invalid'));
   }
 
   /**
@@ -52,11 +52,11 @@ class LoaderTest extends \PHPUnit_Framework_TestCase {
    * @covers ::autoloadPaths()
    */
   public function test_autoload_finderException() {
-    Loader::setClassMap([
+    $loader = new Loader(__DIR__);
+    $loader->setClassMap([
       '\\Acme' => 'DRUPAL_ROOT/file.inc',
     ]);
-    Loader::setSeed(__DIR__);
-    $this->assertFalse(Loader::autoload('Acme'));
+    $this->assertFalse($loader->autoload('Acme'));
   }
 
   /**
@@ -67,10 +67,11 @@ class LoaderTest extends \PHPUnit_Framework_TestCase {
    * @covers ::setClassMap()
    */
   public function test_setClassMap($given, $expected) {
-    Loader::setClassMap($given);
+    $loader = new Loader(__DIR__);
+    $loader->setClassMap($given);
     $reflection_property = new \ReflectionProperty('\Drupal\Composer\ClassLoader\Loader', 'classMap');
     $reflection_property->setAccessible(TRUE);
-    $value = $reflection_property->getValue();
+    $value = $reflection_property->getValue($loader);
     $this->assertEquals($expected, $value);
   }
 
@@ -92,10 +93,11 @@ class LoaderTest extends \PHPUnit_Framework_TestCase {
    * @covers ::setPsrClassMap()
    */
   public function test_setPsrClassMap($given, $expected) {
-    Loader::setPsrClassMap($given);
+    $loader = new Loader(__DIR__);
+    $loader->setPsrClassMap($given);
     $reflection_property = new \ReflectionProperty('\Drupal\Composer\ClassLoader\Loader', 'psrClassMap');
     $reflection_property->setAccessible(TRUE);
-    $value = $reflection_property->getValue();
+    $value = $reflection_property->getValue($loader);
     $this->assertEquals($expected, $value);
   }
 
@@ -121,11 +123,12 @@ class LoaderTest extends \PHPUnit_Framework_TestCase {
    * @covers ::setSeed()
    */
   public function test_setSeed() {
-    $seed = 'Lorem ipsum';
-    Loader::setSeed($seed);
+    $loader = new Loader('Lorem ipsum');
+    $seed = 'Dolor sit';
+    $loader->setSeed($seed);
     $reflection_property = new \ReflectionProperty('\Drupal\Composer\ClassLoader\Loader', 'seed');
     $reflection_property->setAccessible(TRUE);
-    $value = $reflection_property->getValue();
+    $value = $reflection_property->getValue($loader);
     $this->assertEquals($seed, $value);
   }
 
@@ -135,12 +138,13 @@ class LoaderTest extends \PHPUnit_Framework_TestCase {
    * @covers ::registerPsr()
    */
   public function test_registerPsr() {
+    $loader = new Loader('data/docroot/sites/all/modules/testmodule/composer.json');
     // Mock the \Composer\Autoload\ClassLoader loader.
-    $loader = m::mock('\Composer\Autoload\ClassLoader');
-    $loader
+    $classLoader = m::mock('\Composer\Autoload\ClassLoader');
+    $classLoader
       ->shouldReceive('add')
       ->twice();
-    $loader
+    $classLoader
       ->shouldReceive('addPsr4')
       ->once();
 
@@ -155,9 +159,8 @@ class LoaderTest extends \PHPUnit_Framework_TestCase {
         'Drupal\\Kitten\\' => 'DRUPAL_ROOT/file.inc',
       ],
     ];
-    Loader::setPsrClassMap($psrClassMap);
-    Loader::setSeed('data/docroot/sites/all/modules/testmodule/composer.json');
-    Loader::registerPsr($loader);
+    $loader->setPsrClassMap($psrClassMap);
+    $loader->registerPsr($classLoader);
   }
 
 }


### PR DESCRIPTION
This PR depends on #16. Please, merge that one first.

Many things so far were declared as static just in order to declare the autoload callable as a string `Drupal\Composer\ClassLoader\Loader::autoload`. This PR corrects that.

Now the static properties have been moved to regular ones.
