### PR TITLE
Better composer.json detection

### DIFF
--- a/autoload.php
+++ b/autoload.php
@@ -2,6 +2,13 @@
 
 use Drupal\Composer\ClassLoader\AutoloaderBootstrap;
 
+// Register root dir
+if (getenv('COMPOSER_CONFIGURATION_PATH') === false) {
+  putenv('COMPOSER_CONFIGURATION_PATH=' . dirname(dirname(dirname(__DIR__))));
+}
+
+define('COMPOSER_CONFIGURATION_PATH', getenv('COMPOSER_CONFIGURATION_PATH'));
+
 // Load Composer's autoloader.
 $loader = require __DIR__ . '/../../autoload.php';
 

--- a/src/AutoloaderBootstrap.php
+++ b/src/AutoloaderBootstrap.php
@@ -179,7 +179,11 @@ class AutoloaderBootstrap implements AutoloaderBootstrapInterface {
     }
 
     // Get the drupal path configuration.
-    $composer_config = json_decode(file_get_contents(static::COMPOSER_CONFIGURATION_NAME));
+    $composer_path = join(DIRECTORY_SEPARATOR, array(
+        COMPOSER_CONFIGURATION_PATH,
+        static::COMPOSER_CONFIGURATION_NAME,
+    ));
+    $composer_config = json_decode(file_get_contents($composer_path));
     $config['class-location'] = array();
     if (isset($composer_config->autoload->{'class-location'})) {
       $config['class-location'] = array_merge($config['class-location'], (array) $composer_config->autoload->{'class-location'});


### PR DESCRIPTION
By default when using composer dependencies are installed
under vendor directory and the composer.json file is
located at project root. Use this standard to load composer.json
file instead of assuming is in the working directory.

Fixes: #28